### PR TITLE
fix(koier.json): fixed slugs that were invalid. æøå caused errors

### DIFF
--- a/backend/ntnui/fixture/koier.json
+++ b/backend/ntnui/fixture/koier.json
@@ -4,7 +4,7 @@
         "pk": 1,
         "fields": {
             "name": "Flåkoia",
-            "slug": "flåkoia",
+            "slug": "flakoia",
             "number_of_beds": "11",
             "album": "https://plus.google.com/photos/112172516519597975801/albums/6080568101715065937",
             "description": 1,
@@ -28,7 +28,7 @@
         "pk": 3,
         "fields": {
             "name": "Øvensenget",
-            "slug": "øvensenget",
+            "slug": "vensenget",
             "number_of_beds": 8,
             "album": "https://plus.google.com/photos/112172516519597975801/albums/6080573166409468049",
             "description": 3,
@@ -40,7 +40,7 @@
         "pk": 4,
         "fields": {
             "name": "Kåsen",
-            "slug": "kåsen",
+            "slug": "kasen",
             "number_of_beds": 8,
             "album": "https://plus.google.com/photos/112172516519597975801/albums/6080578038282981441",
             "description": 4,
@@ -64,7 +64,7 @@
         "pk": 6,
         "fields": {
             "name": "Holmsåkoia",
-            "slug": "holmsåkoia",
+            "slug": "holmsakoia",
             "number_of_beds": 20,
             "album": "https://plus.google.com/photos/112172516519597975801/albums/6080569143281210241",
             "description": 6,
@@ -126,7 +126,7 @@
         "pk": 11,
         "fields": {
             "name": "Kråklikåten",
-            "slug": "kråklikåten",
+            "slug": "kraklikaten",
             "number_of_beds": 4,
             "album": "https://plus.google.com/photos/112172516519597975801/albums/6080578400525335409",
             "description": 11,
@@ -149,8 +149,8 @@
         "model": "koie_booking.koiemodel",
         "pk": 13,
         "fields": {
-            "slug": "høgnabu",
             "name": "Høgnabu",
+            "slug": "hgnabu",
             "number_of_beds": 6,
             "album": "https://plus.google.com/photos/112172516519597975801/albums/6080569052316127793",
             "description": 13,
@@ -174,7 +174,7 @@
         "pk": 15,
         "fields": {
             "name": "Vekvessætra",
-            "slug": "vekvessætra",
+            "slug": "vekvesstra",
             "number_of_beds": 20,
             "album": "https://plus.google.com/photos/112172516519597975801/albums/6080575085607014849",
             "description": 15,
@@ -198,7 +198,7 @@
         "pk": 17,
         "fields": {
             "name": "Tågåbu",
-            "slug": "tågåbu",
+            "slug": "tagabu",
             "number_of_beds": 6,
             "album": "https://plus.google.com/photos/112172516519597975801/albums/6080575784055585345",
             "description": 17,
@@ -210,7 +210,7 @@
         "pk": 18,
         "fields": {
             "name": "Lynhøgen",
-            "slug": "lynhøgen",
+            "slug": "lynhgen",
             "number_of_beds": 4,
             "album": "https://plus.google.com/photos/112172516519597975801/albums/6080577892059621601",
             "description": 18,
@@ -222,7 +222,7 @@
         "pk": 19,
         "fields": {
             "name": "Selbukåten",
-            "slug": "selbukåten",
+            "slug": "selbukaten",
             "number_of_beds": 2,
             "album": "https://plus.google.com/photos/112172516519597975801/albums/6080576505498474385",
             "description": 19,
@@ -246,7 +246,7 @@
         "pk": 21,
         "fields": {
             "name": "Kamtjønnkoia",
-            "slug": "kamtjønnkoia",
+            "slug": "kamtjnnkoia",
             "number_of_beds": 6,
             "album": "https://plus.google.com/photos/112172516519597975801/albums/6080569664107330017",
             "description": 21,
@@ -258,7 +258,7 @@
         "pk": 22,
         "fields": {
             "name": "Rindalsløa",
-            "slug": "rindalsløa",
+            "slug": "rindalsla",
             "number_of_beds": 4,
             "album": "https://plus.google.com/photos/112172516519597975801/albums/6080577014432205297",
             "description": 22,
@@ -282,7 +282,7 @@
         "pk": 24,
         "fields": {
             "name": "Mortenskåten",
-            "slug": "mortenskåten",
+            "slug": "mortenskaten",
             "number_of_beds": 2,
             "album": "https://plus.google.com/photos/112172516519597975801/albums/6080577671329718881",
             "description": 24,


### PR DESCRIPTION
See task [Back End - Fix invalid koie slugs in test data fixture](https://app.clickup.com/t/9eyxtx)

Test data had invalid slug names for koier. The slugs included "æ", "ø" and "å". This caused errors in slug lookup of koier, and broke endpoints using this. This was fixed by correctly slugifying the koie-names in `koier.json`.

Note this was only an issue with the data being loaded from the fixture files when doing `make dev-clean-install`.
New koier created in the admin panel were still correctly slugified.